### PR TITLE
Fix issue: #4

### DIFF
--- a/cli-clock
+++ b/cli-clock
@@ -230,6 +230,7 @@ while sleep ${delay:-0}; do
 	[[ ${@} ]] && end
 
 	# determine how long to sleep before the next update
-	nanoseconds=10#$(date +%N)
+	nanoseconds=$(date +%N)
+	nanoseconds=${nanoseconds#0}
 	delay=0.$(( 1000000000 - ${nanoseconds} ))
 done


### PR DESCRIPTION
Added "nanoseconds=${nanoseconds#0}" to force base-10 interpretation