### PR TITLE
don't print error message on install

### DIFF
--- a/adblocker.sh
+++ b/adblocker.sh
@@ -88,7 +88,7 @@ sed -ri 's/([^ ]+)$/\1\n::      \1/' "$BLOCKLIST"
 
 
 # add block list to dnsmasq config if it's not already there
-if ! uci get dhcp.@dnsmasq[0].addnhosts | grep -q "$BLOCKLIST"; then
+if ! uci get dhcp.@dnsmasq[0].addnhosts 2> /dev/null | grep -q "$BLOCKLIST"; then
 	uci add_list dhcp.@dnsmasq[0].addnhosts="$BLOCKLIST" && uci commit
 fi
 


### PR DESCRIPTION
when running this script for the first time, the `addnhosts` list is empty resulting in the following message:

 uci: Entry not found

this is not very user-friendly for the uninitiated :)